### PR TITLE
SWI-1166, SWI-1299 Multi p4 profile support for bfn sde

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -107,6 +107,13 @@ config_syncd_marvell()
 
 config_syncd_barefoot()
 {
+    # Check and load SDE profile
+    P4_PROFILE=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["p4_profile"]')
+    if [[ -n "$P4_PROFILE" ]]; then
+        if [[ ( -d /opt/bfn/install_${P4_PROFILE} ) && ( -L /opt/bfn/install || ! -e /opt/bfn/install ) ]]; then
+            ln -srfn /opt/bfn/install_${P4_PROFILE} /opt/bfn/install
+        fi
+    fi
     export ONIE_PLATFORM=`grep onie_platform /etc/machine.conf | awk 'BEGIN { FS = "=" } ; { print $2 }'`
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/bfn/install/lib/platform/$ONIE_PLATFORM:/opt/bfn/install/lib:/opt/bfn/install/lib/tofinopd/switch
      . /opt/bfn/install/bin/dma_setup.sh


### PR DESCRIPTION
Retains original behavior if only one profile is packaged in sde or when profile is not specified in sonic config.